### PR TITLE
Fix three destroy paths that release the wrong I/O ports

### DIFF
--- a/blueMSX/Src/IoDevice/Sf7000PPI.c
+++ b/blueMSX/Src/IoDevice/Sf7000PPI.c
@@ -49,6 +49,8 @@ typedef struct {
 
 static void destroy(Sf7000PPI* ppi)
 {
+    ioPortUnregister(0xe0);
+    ioPortUnregister(0xe1);
     ioPortUnregister(0xe4);
     ioPortUnregister(0xe5);
     ioPortUnregister(0xe6);

--- a/blueMSX/Src/Memory/romMapperKanji12.c
+++ b/blueMSX/Src/Memory/romMapperKanji12.c
@@ -71,11 +71,6 @@ static void destroy(RomMapperKanji12* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0xd9);
-    ioPortUnregister(0xd8);
-    ioPortUnregister(0xda);
-    ioPortUnregister(0xdb);
-
     free(rm->romData);
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperOpcodeModule.c
+++ b/blueMSX/Src/Memory/romMapperOpcodeModule.c
@@ -135,14 +135,14 @@ static void loadState(RomMapperOpcodeModule* rm)
 
 static void destroy(RomMapperOpcodeModule* rm)
 {
-    int i;
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
     ay8910Destroy(rm->ay8910);
 
-    for (i = 0; i < 16; i++) {
-        ioPortUnregister(0x60 + i);
-    }
+    ioPortUnregister(0x40);
+    ioPortUnregister(0x50);
+    ioPortUnregister(0x51);
+    ioPortUnregister(0x52);
 
     free(rm);
 }


### PR DESCRIPTION
I/O ポートの解放が、そのデバイスが登録した内容と食い違っている箇所が 3 つあります。

いずれも現在の「1 ポートに 1 デバイス」というテーブルの性質に隠れていて、
今のところ実害が出にくい状態です。二重に解放しても既に `NULL` なので何も起きず、
解放し忘れても次に登録するデバイスが上書きするためです。

### 1. `romMapperKanji12` が他のデバイスのポートを解放している

`destroy()` が `0xD8`-`0xDB` を解放していますが、このデバイスが登録するのは
`ioPortRegisterSub(0xF7, ...)` だけです。`0xD8`-`0xDB` は `romMapperKanji` が
登録しているものなので、**Kanji12 を破棄すると、まだ生きている漢字 ROM の
ポートが消えます。**

### 2. `romMapperOpcodeModule` が、登録したポートを解放していない

登録しているのは `0x40` と `0x50`-`0x52` ですが、`destroy()` が解放しているのは
`0x60`-`0x6F` で、**このデバイスが一度も登録していないアドレス**です。
登録した 4 本はどこでも解放されません。

### 3. `Sf7000PPI` の解放漏れ

`0xE0` / `0xE1` を登録していますが、`destroy()` は `0xE4`-`0xE7` しか
解放していません。

## 確認したこと

ビルドが通ること、`/listmachines` の結果が変わらないことを確認しました。

**これらの経路が実際に通るのは「マシンが動いたままデバイスが破棄されるとき」**
なので、そこは踏んでいません。

## 補足

これらは、1 つのポートに複数のデバイスを登録できるようにしようとして
見つけたものです。そちらは別に issue を立てます。
重ね合わせを許すと、上記はいずれも実害のある不具合になります
（他人の登録が消える／古い登録が残ったまま新しい登録が重なる）。
このプルリクエストは**現在の挙動のままで成立する修正だけ**を含んでいます。

---

<details>
<summary>English</summary>

Three places release I/O ports that do not match what the device registered.

All three are hidden by the current one-device-per-port table and rarely
bite today: releasing a port twice does nothing because it is already `NULL`,
and failing to release one is masked by whoever registers next.

### 1. `romMapperKanji12` releases another device's ports

`destroy()` releases `0xD8`-`0xDB`, but this device only ever registers
`ioPortRegisterSub(0xF7, ...)`. Those four ports belong to `romMapperKanji`,
so **destroying a Kanji12 device takes the ports away from a kanji ROM that
is still alive.**

### 2. `romMapperOpcodeModule` never releases what it registered

It registers `0x40` and `0x50`-`0x52`, but `destroy()` releases `0x60`-`0x6F`,
**addresses this device never registers**. The four it does register are
never released anywhere.

### 3. `Sf7000PPI` leaks two ports

It registers `0xE0` / `0xE1`, but `destroy()` only releases `0xE4`-`0xE7`.

## What was checked

The build passes and `/listmachines` returns the same result as before.

**These paths are only reached when a device is destroyed while the machine
keeps running**, and I have not exercised that.

## Context

I found these while trying to let more than one device register the same
port; I will open a separate issue for that. Once ports can be shared, each
of the three becomes a real bug — one removes a live device's registration,
and the other two leave a stale registration for a new one to stack on top of.
This pull request contains **only the fixes that stand on their own under the
current behaviour**.

</details>
