### PR TITLE
Let several devices answer the same I/O port (proposal for #78)

### DIFF
--- a/blueMSX/Src/Board/Adam.c
+++ b/blueMSX/Src/Board/Adam.c
@@ -270,7 +270,7 @@ static void colecoJoyIoDestroy(void* dummy)
 {
     int i;
     for (i = 0xe0; i <= 0xff; i++) {
-        ioPortUnregister(i);
+        ioPortUnregister(i, NULL);
     }
     
     if (joyDevice[0] != NULL && joyDevice[0]->destroy != NULL) {

--- a/blueMSX/Src/Board/Coleco.c
+++ b/blueMSX/Src/Board/Coleco.c
@@ -243,7 +243,7 @@ static void colecoJoyIoDestroy(void* dummy)
 {
     int i;
     for (i = 0xe0; i <= 0xff; i++) {
-        ioPortUnregister(i);
+        ioPortUnregister(i, NULL);
     }
     
     if (joyDevice[0] != NULL && joyDevice[0]->destroy != NULL) {

--- a/blueMSX/Src/Board/MSX.c
+++ b/blueMSX/Src/Board/MSX.c
@@ -106,7 +106,7 @@ static void destroy() {
 
     r800DebugDestroy();
     
-	ioPortUnregister(0x2e);
+	ioPortUnregister(0x2e, NULL);
 
     deviceManagerDestroy();
 

--- a/blueMSX/Src/Board/SG1000.c
+++ b/blueMSX/Src/Board/SG1000.c
@@ -107,13 +107,13 @@ static void sg1000IoPortDestroy(void* dummy)
 	int i;
 
 	for (i=0x40; i<0x80; i++)
-		ioPortUnregister(i);
+		ioPortUnregister(i, NULL);
 
 	for (i=0xC0; i<0x100; i+=2)
-		ioPortUnregister(i);
+		ioPortUnregister(i, NULL);
 
-	ioPortUnregister(0xc1);
-	ioPortUnregister(0xdd);
+	ioPortUnregister(0xc1, NULL);
+	ioPortUnregister(0xdd, NULL);
 }
 
 static void sg1000IoPortCreate()

--- a/blueMSX/Src/IoDevice/MSXMidi.c
+++ b/blueMSX/Src/IoDevice/MSXMidi.c
@@ -113,7 +113,7 @@ static void loadState(MSXMidi* msxMidi)
 
 static void destroy(MSXMidi* msxMidi)
 {
-    ioPortUnregister(0xe2);
+    ioPortUnregister(0xe2, msxMidi);
     unregisterIoPorts(msxMidi);
 
     midiIoDestroy(msxMidi->midiIo);
@@ -285,7 +285,7 @@ static void unregisterIoPorts(MSXMidi* msxMidi) {
     }
     
     for (i = 0; i < (msxMidi->ioStart == 0xe0 ? 2 : 8); i++) {
-        ioPortUnregister(msxMidi->ioStart + i);
+        ioPortUnregister(msxMidi->ioStart + i, msxMidi);
     }
 
     msxMidi->ioStart = 0;

--- a/blueMSX/Src/IoDevice/MsxPPI.c
+++ b/blueMSX/Src/IoDevice/MsxPPI.c
@@ -67,10 +67,10 @@ typedef struct {
 
 static void destroy(MsxPPI* ppi)
 {
-    ioPortUnregister(0xa8);
-    ioPortUnregister(0xa9);
-    ioPortUnregister(0xaa);
-    ioPortUnregister(0xab);
+    ioPortUnregister(0xa8, ppi->i8255);
+    ioPortUnregister(0xa9, ppi->i8255);
+    ioPortUnregister(0xaa, ppi->i8255);
+    ioPortUnregister(0xab, ppi->i8255);
 
     audioKeyClickDestroy(ppi->keyClick);
     audioCassetteDestroy(ppi->cassette);

--- a/blueMSX/Src/IoDevice/RTC.c
+++ b/blueMSX/Src/IoDevice/RTC.c
@@ -365,8 +365,8 @@ void rtcDestroy(RTC* rtc)
 {
     debugDeviceUnregister(rtc->debugHandle);
 
-    ioPortUnregister(0xb4);
-    ioPortUnregister(0xb5);
+    ioPortUnregister(0xb4, rtc);
+    ioPortUnregister(0xb5, rtc);
 
     if (rtc->cmosName[0]) {
         FILE* file = fopen(rtc->cmosName, "w");

--- a/blueMSX/Src/IoDevice/Sc3000PPI.c
+++ b/blueMSX/Src/IoDevice/Sc3000PPI.c
@@ -147,10 +147,10 @@ static UInt16 getKeyState(Sc3000PPI* ppi)
 
 static void destroy(Sc3000PPI* ppi)
 {
-    ioPortUnregister(0xdc);
-    ioPortUnregister(0xdd);
-    ioPortUnregister(0xde);
-    ioPortUnregister(0xdf);
+    ioPortUnregister(0xdc, ppi->i8255);
+    ioPortUnregister(0xdd, ppi->i8255);
+    ioPortUnregister(0xde, ppi->i8255);
+    ioPortUnregister(0xdf, ppi->i8255);
 
     deviceManagerUnregister(ppi->deviceHandle);
     debugDeviceUnregister(ppi->debugHandle);

--- a/blueMSX/Src/IoDevice/Sf7000PPI.c
+++ b/blueMSX/Src/IoDevice/Sf7000PPI.c
@@ -49,12 +49,12 @@ typedef struct {
 
 static void destroy(Sf7000PPI* ppi)
 {
-    ioPortUnregister(0xe0);
-    ioPortUnregister(0xe1);
-    ioPortUnregister(0xe4);
-    ioPortUnregister(0xe5);
-    ioPortUnregister(0xe6);
-    ioPortUnregister(0xe7);
+    ioPortUnregister(0xe0, ppi);
+    ioPortUnregister(0xe1, ppi);
+    ioPortUnregister(0xe4, ppi);
+    ioPortUnregister(0xe5, ppi);
+    ioPortUnregister(0xe6, ppi);
+    ioPortUnregister(0xe7, ppi);
 
     deviceManagerUnregister(ppi->deviceHandle);
     debugDeviceUnregister(ppi->debugHandle);

--- a/blueMSX/Src/IoDevice/SviPPI.c
+++ b/blueMSX/Src/IoDevice/SviPPI.c
@@ -132,11 +132,11 @@ typedef struct {
 
 static void destroy(SviPPI* ppi)
 {
-    ioPortUnregister(0x98);
-    ioPortUnregister(0x99);
-    ioPortUnregister(0x96);
-    ioPortUnregister(0x97);
-    ioPortUnregister(0x9A);
+    ioPortUnregister(0x98, ppi->i8255);
+    ioPortUnregister(0x99, ppi->i8255);
+    ioPortUnregister(0x96, ppi->i8255);
+    ioPortUnregister(0x97, ppi->i8255);
+    ioPortUnregister(0x9A, ppi);
 
     audioKeyClickDestroy(ppi->keyClick);
     deviceManagerUnregister(ppi->deviceHandle);

--- a/blueMSX/Src/IoDevice/TurboRIO.c
+++ b/blueMSX/Src/IoDevice/TurboRIO.c
@@ -57,7 +57,7 @@ static UInt8 read(TurboRIO* turboRIO, UInt16 ioPort)
 
 static void destroy(TurboRIO* turboRIO)
 {
-    ioPortUnregister(0xa7);
+    ioPortUnregister(0xa7, turboRIO);
 
     debugDeviceUnregister(turboRIO->debugHandle);
     deviceManagerUnregister(turboRIO->deviceHandle);

--- a/blueMSX/Src/Memory/IoPort.c
+++ b/blueMSX/Src/Memory/IoPort.c
@@ -34,15 +34,24 @@
 #include <string.h>
 #include <stdio.h>
 
-typedef struct IoPortInfo {
+/* Room for the overlaps real hardware produces - a cartridge sound chip
+** doubling a built-in one - with slack. Claims past this are dropped. */
+#define IO_PORT_MAX_CLAIMS 4
+
+typedef struct IoPortClaim {
     IoPortRead  read;
     IoPortWrite write;
     void*       ref;
+} IoPortClaim;
+
+typedef struct IoPortInfo {
+    IoPortClaim claim[IO_PORT_MAX_CLAIMS];
+    int         count;
 } IoPortInfo;
 
-static IoPortInfo ioTable[256];
-static IoPortInfo ioSubTable[256];
-static IoPortInfo ioUnused[2];
+static IoPortInfo  ioTable[256];
+static IoPortClaim ioSubTable[256];
+static IoPortClaim ioUnused[2];
 static int currentSubport;
 
 void ioPortReset()
@@ -55,27 +64,48 @@ void ioPortReset()
 
 void* ioPortGetRef(int port)
 {
-	return ioTable[port].ref;
+	return ioTable[port].count > 0 ? ioTable[port].claim[0].ref : NULL;
 }
 
 void ioPortRegister(int port, IoPortRead read, IoPortWrite write, void* ref)
 {
-    if (ioTable[port].read  == NULL && 
-        ioTable[port].write == NULL && 
-        ioTable[port].ref   == NULL)
-    {
-        ioTable[port].read  = read;
-        ioTable[port].write = write;
-        ioTable[port].ref   = ref;
+    IoPortInfo* info = &ioTable[port];
+    int i;
+
+    for (i = 0; i < info->count; i++) {
+        if (info->claim[i].ref == ref) {
+            info->claim[i].read  = read;
+            info->claim[i].write = write;
+            return;
+        }
     }
+
+    if (info->count == IO_PORT_MAX_CLAIMS) {
+        return;
+    }
+
+    info->claim[info->count].read  = read;
+    info->claim[info->count].write = write;
+    info->claim[info->count].ref   = ref;
+    info->count++;
 }
 
 
-void ioPortUnregister(int port)
+void ioPortUnregister(int port, void* ref)
 {
-    ioTable[port].read  = NULL;
-    ioTable[port].write = NULL;
-    ioTable[port].ref   = NULL;
+    IoPortInfo* info = &ioTable[port];
+    int i;
+
+    for (i = 0; i < info->count; i++) {
+        if (info->claim[i].ref == ref) {
+            info->count--;
+            /* Writes go out in claim order, so close the gap rather than
+            ** swapping the last entry into it. */
+            memmove(&info->claim[i], &info->claim[i + 1],
+                    (size_t)(info->count - i) * sizeof(IoPortClaim));
+            return;
+        }
+    }
 }
 
 void ioPortRegisterUnused(int idx, IoPortRead read, IoPortWrite write, void* ref)
@@ -112,8 +142,25 @@ int ioPortCheckSub(int subport)
     return currentSubport == subport;
 }
 
+/* A handler may claim or release ports while it runs - an I/O enabler does
+** exactly that - so walk a copy instead of the live table. */
+static int ioPortTakeClaims(int port, IoPortClaim* out)
+{
+    int count = ioTable[port].count;
+
+    memcpy(out, ioTable[port].claim, (size_t)count * sizeof(IoPortClaim));
+
+    return count;
+}
+
 UInt8 ioPortRead(void* ref, UInt16 port)
 {
+    IoPortClaim claim[IO_PORT_MAX_CLAIMS];
+    UInt8 value = 0xff;
+    int driven = 0;
+    int count;
+    int i;
+
     port &= 0xff;
 
     if (boardGetType() == BOARD_MSX && port >= 0x40 && port < 0x50) {
@@ -124,21 +171,37 @@ UInt8 ioPortRead(void* ref, UInt16 port)
         return ioSubTable[currentSubport].read(ioSubTable[currentSubport].ref, port);
     }
 
-    if (ioTable[port].read == NULL) {
-        if (ioUnused[0].read != NULL) {
-            return ioUnused[0].read(ioUnused[0].ref, port);
+    count = ioPortTakeClaims(port, claim);
+
+    for (i = 0; i < count; i++) {
+        if (claim[i].read != NULL) {
+            /* Two cards answering at once pull the bus down together. */
+            value &= claim[i].read(claim[i].ref, port);
+            driven = 1;
         }
-        if (ioUnused[1].read != NULL) {
-            return ioUnused[1].read(ioUnused[1].ref, port);
-        }
-        return 0xff;
     }
 
-    return ioTable[port].read(ioTable[port].ref, port);
+    if (driven) {
+        return value;
+    }
+
+    if (ioUnused[0].read != NULL) {
+        return ioUnused[0].read(ioUnused[0].ref, port);
+    }
+    if (ioUnused[1].read != NULL) {
+        return ioUnused[1].read(ioUnused[1].ref, port);
+    }
+
+    return 0xff;
 }
 
 void  ioPortWrite(void* ref, UInt16 port, UInt8 value)
 {
+    IoPortClaim claim[IO_PORT_MAX_CLAIMS];
+    int taken = 0;
+    int count;
+    int i;
+
     boardCheckFdcBoostKill(port, value);
 
     port &= 0xff;
@@ -155,15 +218,23 @@ void  ioPortWrite(void* ref, UInt16 port, UInt8 value)
         return;
     }
 
-    if (ioTable[port].write != NULL) {
-        ioTable[port].write(ioTable[port].ref, port, value);
+    count = ioPortTakeClaims(port, claim);
+
+    for (i = 0; i < count; i++) {
+        if (claim[i].write != NULL) {
+            claim[i].write(claim[i].ref, port, value);
+            taken = 1;
+        }
     }
-    else if (ioUnused[0].write != NULL) {
+
+    if (taken) {
+        return;
+    }
+
+    if (ioUnused[0].write != NULL) {
         ioUnused[0].write(ioUnused[0].ref, port, value);
     }
     else if (ioUnused[1].write != NULL) {
         ioUnused[1].write(ioUnused[1].ref, port, value);
     }
 }
-
-

--- a/blueMSX/Src/Memory/IoPort.h
+++ b/blueMSX/Src/Memory/IoPort.h
@@ -34,8 +34,14 @@ typedef UInt8 (*IoPortRead)(void*, UInt16);
 typedef void  (*IoPortWrite)(void*, UInt16, UInt8);
 
 void* ioPortGetRef(int port);
+
+/* More than one device may claim the same port, which is what happens on a
+** real bus when a cartridge doubles a chip the machine already has. A write
+** reaches every claim; a read is the AND of the claims that drive one. The
+** ref identifies the caller's own claim, so releasing one device leaves the
+** others answering. */
 void ioPortRegister(int port, IoPortRead read, IoPortWrite write, void* ref);
-void ioPortUnregister(int port);
+void ioPortUnregister(int port, void* ref);
 
 void ioPortRegisterUnused(int idx, IoPortRead read, IoPortWrite write, void* ref);
 void ioPortUnregisterUnused(int idx);

--- a/blueMSX/Src/Memory/ramMapperIo.c
+++ b/blueMSX/Src/Memory/ramMapperIo.c
@@ -97,10 +97,10 @@ static void loadState(RamMapperIo* rm)
 
 static void destroy(RamMapperIo* rm) 
 {
-    ioPortUnregister(0xfc);
-    ioPortUnregister(0xfd);
-    ioPortUnregister(0xfe);
-    ioPortUnregister(0xff);
+    ioPortUnregister(0xfc, rm);
+    ioPortUnregister(0xfd, rm);
+    ioPortUnregister(0xfe, rm);
+    ioPortUnregister(0xff, rm);
 
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);

--- a/blueMSX/Src/Memory/romMapperArc.c
+++ b/blueMSX/Src/Memory/romMapperArc.c
@@ -51,7 +51,7 @@ typedef struct {
 
 static void destroy(Arc* rm)
 {
-    ioPortUnregister(0x7f);
+    ioPortUnregister(0x7f, rm);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperBeerIDE.c
+++ b/blueMSX/Src/Memory/romMapperBeerIDE.c
@@ -118,10 +118,10 @@ static void loadState(RomMapperBeerIde* rm)
 
 static void destroy(RomMapperBeerIde* rm)
 {
-    ioPortUnregister(0x30);
-    ioPortUnregister(0x31);
-    ioPortUnregister(0x32);
-    ioPortUnregister(0x33);
+    ioPortUnregister(0x30, rm->i8255);
+    ioPortUnregister(0x31, rm->i8255);
+    ioPortUnregister(0x32, rm->i8255);
+    ioPortUnregister(0x33, rm->i8255);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperF4device.c
+++ b/blueMSX/Src/Memory/romMapperF4device.c
@@ -66,7 +66,7 @@ static void destroy(RomMapperF4device* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0xf4);
+    ioPortUnregister(0xf4, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperFMPAC.c
+++ b/blueMSX/Src/Memory/romMapperFMPAC.c
@@ -104,8 +104,8 @@ static void destroy(RomMapperFMPAC* rm)
 {
     sramSave(rm->sramFilename, rm->sram, 0x1ffe, pacHeader, (int)strlen(pacHeader));
 
-    ioPortUnregister(0x7c);
-    ioPortUnregister(0x7d);
+    ioPortUnregister(0x7c, rm);
+    ioPortUnregister(0x7d, rm);
     
     if (rm->ym2413 != NULL) {
         ym2413Destroy(rm->ym2413);

--- a/blueMSX/Src/Memory/romMapperFMPAK.c
+++ b/blueMSX/Src/Memory/romMapperFMPAK.c
@@ -77,8 +77,8 @@ static void destroy(void* arg)
 {
     RomMapperFMPAK* rm = (RomMapperFMPAK*)arg;
 
-    ioPortUnregister(0x7c);
-    ioPortUnregister(0x7d);
+    ioPortUnregister(0x7c, rm);
+    ioPortUnregister(0x7d, rm);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperGIDE.c
+++ b/blueMSX/Src/Memory/romMapperGIDE.c
@@ -81,18 +81,18 @@ static void destroy(RomMapperGIde* rm)
 
     portBase = (boardGetType() == BOARD_SVI) ? 0x40:0x60;
 
-    ioPortUnregister(portBase | 0x04);
-    ioPortUnregister(portBase | 0x05);
-    ioPortUnregister(portBase | 0x06);
-    ioPortUnregister(portBase | 0x07);
-    ioPortUnregister(portBase | 0x08);
-    ioPortUnregister(portBase | 0x09);
-    ioPortUnregister(portBase | 0x0a);
-    ioPortUnregister(portBase | 0x0b);
-    ioPortUnregister(portBase | 0x0c);
-    ioPortUnregister(portBase | 0x0d);
-    ioPortUnregister(portBase | 0x0e);
-    ioPortUnregister(portBase | 0x0f);
+    ioPortUnregister(portBase | 0x04, rm);
+    ioPortUnregister(portBase | 0x05, rm);
+    ioPortUnregister(portBase | 0x06, rm);
+    ioPortUnregister(portBase | 0x07, rm);
+    ioPortUnregister(portBase | 0x08, rm);
+    ioPortUnregister(portBase | 0x09, rm);
+    ioPortUnregister(portBase | 0x0a, rm);
+    ioPortUnregister(portBase | 0x0b, rm);
+    ioPortUnregister(portBase | 0x0c, rm);
+    ioPortUnregister(portBase | 0x0d, rm);
+    ioPortUnregister(portBase | 0x0e, rm);
+    ioPortUnregister(portBase | 0x0f, rm);
 
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);

--- a/blueMSX/Src/Memory/romMapperGoudaSCSI.c
+++ b/blueMSX/Src/Memory/romMapperGoudaSCSI.c
@@ -89,9 +89,9 @@ static void reset(RomMapperGoudaSCSI* rm)
 
 static void destroy(RomMapperGoudaSCSI* rm)
 {
-    ioPortUnregister(PORT_BASE + 0);
-    ioPortUnregister(PORT_BASE + 1);
-    ioPortUnregister(PORT_BASE + 2);
+    ioPortUnregister(PORT_BASE + 0, rm->wd33c93);
+    ioPortUnregister(PORT_BASE + 1, rm->wd33c93);
+    ioPortUnregister(PORT_BASE + 2, rm);
 
     debugDeviceUnregister(rm->debugHandle);
     slotUnregister(rm->slot, rm->sslot, rm->startPage);

--- a/blueMSX/Src/Memory/romMapperJoyrexPsg.c
+++ b/blueMSX/Src/Memory/romMapperJoyrexPsg.c
@@ -59,7 +59,7 @@ static void destroy(RomMapperJoyrexPsg* rm)
     debugDeviceUnregister(rm->debugHandle);
     sn76489Destroy(rm->sn76489);
 
-    ioPortUnregister(0xf0);
+    ioPortUnregister(0xf0, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperKanji.c
+++ b/blueMSX/Src/Memory/romMapperKanji.c
@@ -70,10 +70,10 @@ static void destroy(RomMapperKanji* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0xd9);
-    ioPortUnregister(0xd8);
-    ioPortUnregister(0xda);
-    ioPortUnregister(0xdb);
+    ioPortUnregister(0xd9, rm);
+    ioPortUnregister(0xd8, rm);
+    ioPortUnregister(0xda, rm);
+    ioPortUnregister(0xdb, rm);
 
     free(rm->romData);
     free(rm);

--- a/blueMSX/Src/Memory/romMapperKonamiKeyboardMaster.c
+++ b/blueMSX/Src/Memory/romMapperKonamiKeyboardMaster.c
@@ -73,8 +73,8 @@ static void loadState(RomMapperKonamiKeyboardMaster* rm)
 
 static void destroy(RomMapperKonamiKeyboardMaster* rm)
 {
-    ioPortUnregister(0x00);
-    ioPortUnregister(0x20);
+    ioPortUnregister(0x00, rm);
+    ioPortUnregister(0x20, rm);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperKorean90.c
+++ b/blueMSX/Src/Memory/romMapperKorean90.c
@@ -82,7 +82,7 @@ static void loadState(RomMapperKorean90* rm)
 
 static void destroy(RomMapperKorean90* rm)
 {
-    if (ioPortGetRef(0x77)&&ioPortGetRef(0x77)==rm) ioPortUnregister(0x77);
+    ioPortUnregister(0x77, rm);
     
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperMegaFlashRomScc.c
+++ b/blueMSX/Src/Memory/romMapperMegaFlashRomScc.c
@@ -133,9 +133,9 @@ static void destroy(RomMapperMegaFlashRomScc* rm)
         ay8910Destroy(rm->ay8910);
     sccDestroy(rm->scc);
 
-    ioPortUnregister(0x10);
-    ioPortUnregister(0x11);
-    ioPortUnregister(0x12);
+    ioPortUnregister(0x10, rm);
+    ioPortUnregister(0x11, rm);
+    ioPortUnregister(0x12, rm);
 
     free(rm->romData);
     free(rm);

--- a/blueMSX/Src/Memory/romMapperMegaFlashRomSccPlusSD.c
+++ b/blueMSX/Src/Memory/romMapperMegaFlashRomSccPlusSD.c
@@ -561,9 +561,9 @@ static void destroy(RomMapperMfrSccSd* rm)
     if (rm->sdCard[0]) sdCardDestroy(rm->sdCard[0]);
     if (rm->sdCard[1]) sdCardDestroy(rm->sdCard[1]);
 
-    ioPortUnregister(0x10);
-    ioPortUnregister(0x11);
-    ioPortUnregister(0x12);
+    ioPortUnregister(0x10, rm);
+    ioPortUnregister(0x11, rm);
+    ioPortUnregister(0x12, rm);
 
     ramMapperIoRemove(rm->memMapperIoHandle);
 

--- a/blueMSX/Src/Memory/romMapperMegaRAM.c
+++ b/blueMSX/Src/Memory/romMapperMegaRAM.c
@@ -95,7 +95,7 @@ static void loadState(RomMapperMegaRAM* rm)
 
 static void destroy(RomMapperMegaRAM* rm)
 {
-    ioPortUnregister(0x8e);
+    ioPortUnregister(0x8e, rm);
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);

--- a/blueMSX/Src/Memory/romMapperMicrosol.c
+++ b/blueMSX/Src/Memory/romMapperMicrosol.c
@@ -52,11 +52,11 @@ typedef struct {
 
 static void destroy(Microsol* rm)
 {
-    ioPortUnregister(0xd0);
-    ioPortUnregister(0xd1);
-    ioPortUnregister(0xd2);
-    ioPortUnregister(0xd3);
-    ioPortUnregister(0xd4);
+    ioPortUnregister(0xd0, rm);
+    ioPortUnregister(0xd1, rm);
+    ioPortUnregister(0xd2, rm);
+    ioPortUnregister(0xd3, rm);
+    ioPortUnregister(0xd4, rm);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperMoonsound.c
+++ b/blueMSX/Src/Memory/romMapperMoonsound.c
@@ -46,12 +46,12 @@ typedef struct {
 
 static void destroy(RomMapperMoonsound* rm)
 {
-    ioPortUnregister(0x7e);
-    ioPortUnregister(0x7f);
-    ioPortUnregister(0xc4);
-    ioPortUnregister(0xc5);
-    ioPortUnregister(0xc6);
-    ioPortUnregister(0xc7);
+    ioPortUnregister(0x7e, rm);
+    ioPortUnregister(0x7f, rm);
+    ioPortUnregister(0xc4, rm);
+    ioPortUnregister(0xc5, rm);
+    ioPortUnregister(0xc6, rm);
+    ioPortUnregister(0xc7, rm);
 
     if (rm->moonsound != NULL) {
         moonsoundDestroy(rm->moonsound);

--- a/blueMSX/Src/Memory/romMapperMsxAudio.c
+++ b/blueMSX/Src/Memory/romMapperMsxAudio.c
@@ -343,21 +343,19 @@ static void destroy(RomMapperMsxAudio* rm)
         philipsMidiDestroy(rm->midi);
     }
 
-    ioPortUnregister(0x00);
-    ioPortUnregister(0x01);
-    ioPortUnregister(0x04);
-    ioPortUnregister(0x05);
+    ioPortUnregister(0x00, rm);
+    ioPortUnregister(0x01, rm);
+    ioPortUnregister(0x04, rm);
+    ioPortUnregister(0x05, rm);
 
-    ioPortUnregister(rm->ioBase + 0);
-    ioPortUnregister(rm->ioBase + 1);
+    ioPortUnregister(rm->ioBase + 0, rm->y8950);
+    ioPortUnregister(rm->ioBase + 1, rm->y8950);
     
     if (rm->y8950) {
-    	if (ioPortGetRef(0xc0)==rm->y8950&&ioPortGetRef(0xc1)==rm->y8950) {
-    		ioPortUnregister(0xc0); ioPortUnregister(0xc1);
-    	}
-    	if (ioPortGetRef(0xc2)==rm->y8950&&ioPortGetRef(0xc3)==rm->y8950) {
-    		ioPortUnregister(0xc2); ioPortUnregister(0xc3);
-    	}
+    	ioPortUnregister(0xc0, rm->y8950);
+    	ioPortUnregister(0xc1, rm->y8950);
+    	ioPortUnregister(0xc2, rm->y8950);
+    	ioPortUnregister(0xc3, rm->y8950);
     }
 
     deviceCount--;
@@ -400,7 +398,7 @@ static void write(RomMapperMsxAudio* rm, UInt16 address, UInt8 value)
 			ioPortRegister(0xc1, y8950Read, y8950Write, rm->y8950);
 		}
 		else if (ioPortGetRef(0xc0)==rm->y8950&&ioPortGetRef(0xc1)==rm->y8950) {
-			ioPortUnregister(0xc0); ioPortUnregister(0xc1);
+			ioPortUnregister(0xc0, rm->y8950); ioPortUnregister(0xc1, rm->y8950);
 		}
 		
 		if (value&2) {
@@ -408,7 +406,7 @@ static void write(RomMapperMsxAudio* rm, UInt16 address, UInt8 value)
 			ioPortRegister(0xc3, y8950Read, y8950Write, rm->y8950);
 		}
 		else if (ioPortGetRef(0xc2)==rm->y8950&&ioPortGetRef(0xc3)==rm->y8950) {
-			ioPortUnregister(0xc2); ioPortUnregister(0xc3);
+			ioPortUnregister(0xc2, rm->y8950); ioPortUnregister(0xc3, rm->y8950);
 		}
 	}
 #endif

--- a/blueMSX/Src/Memory/romMapperMsxMusic.c
+++ b/blueMSX/Src/Memory/romMapperMsxMusic.c
@@ -50,8 +50,8 @@ typedef struct {
 
 static void destroy(MsxMusic* rm)
 {
-    ioPortUnregister(0x7c);
-    ioPortUnregister(0x7d);
+    ioPortUnregister(0x7c, rm);
+    ioPortUnregister(0x7d, rm);
 
     if (rm->ym2413 != NULL) {
         ym2413Destroy(rm->ym2413);

--- a/blueMSX/Src/Memory/romMapperMsxPrn.c
+++ b/blueMSX/Src/Memory/romMapperMsxPrn.c
@@ -68,8 +68,8 @@ static void destroy(RomMapperMsxPrn* prn)
     deviceManagerUnregister(prn->deviceHandle);
     debugDeviceUnregister(prn->debugHandle);
 
-    ioPortUnregister(0x90);
-    ioPortUnregister(0x91);
+    ioPortUnregister(0x90, prn);
+    ioPortUnregister(0x91, prn);
 
     printerIODestroy(prn->printerIO);
 

--- a/blueMSX/Src/Memory/romMapperMsxRs232.c
+++ b/blueMSX/Src/Memory/romMapperMsxRs232.c
@@ -114,13 +114,13 @@ static void loadState(MSXRs232* msxRs232)
 
 static void destroy(MSXRs232* msxRs232)
 {
-    ioPortUnregister(0x80);
-    ioPortUnregister(0x81);
-    ioPortUnregister(0x82);
-    ioPortUnregister(0x84);
-    ioPortUnregister(0x85);
-    ioPortUnregister(0x86);
-    ioPortUnregister(0x87);
+    ioPortUnregister(0x80, msxRs232);
+    ioPortUnregister(0x81, msxRs232);
+    ioPortUnregister(0x82, msxRs232);
+    ioPortUnregister(0x84, msxRs232);
+    ioPortUnregister(0x85, msxRs232);
+    ioPortUnregister(0x86, msxRs232);
+    ioPortUnregister(0x87, msxRs232);
        
     i8251Destroy(msxRs232->i8251);
     i8254Destroy(msxRs232->i8254);

--- a/blueMSX/Src/Memory/romMapperNms1210Rs232.c
+++ b/blueMSX/Src/Memory/romMapperNms1210Rs232.c
@@ -114,15 +114,15 @@ static void loadState(NMS1210Rs232* nms1210Rs232)
 
 static void destroy(NMS1210Rs232* nms1210Rs232)
 {
-    ioPortUnregister(0x37);
-    ioPortUnregister(0x38);
-    ioPortUnregister(0x39);
-    ioPortUnregister(0x3a);
-    ioPortUnregister(0x3b);
-    ioPortUnregister(0x3c);
-    ioPortUnregister(0x3d);
-    ioPortUnregister(0x3e);
-    ioPortUnregister(0x3f);
+    ioPortUnregister(0x37, nms1210Rs232);
+    ioPortUnregister(0x38, nms1210Rs232);
+    ioPortUnregister(0x39, nms1210Rs232);
+    ioPortUnregister(0x3a, nms1210Rs232);
+    ioPortUnregister(0x3b, nms1210Rs232);
+    ioPortUnregister(0x3c, nms1210Rs232);
+    ioPortUnregister(0x3d, nms1210Rs232);
+    ioPortUnregister(0x3e, nms1210Rs232);
+    ioPortUnregister(0x3f, nms1210Rs232);
 
     z8530Destroy(nms1210Rs232->z8530);
     i8254Destroy(nms1210Rs232->i8254);

--- a/blueMSX/Src/Memory/romMapperOpcodeBios.c
+++ b/blueMSX/Src/Memory/romMapperOpcodeBios.c
@@ -73,7 +73,7 @@ static void destroy(RomMapperOpcodeBios* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0x40);
+    ioPortUnregister(0x40, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperOpcodeMegaRam.c
+++ b/blueMSX/Src/Memory/romMapperOpcodeMegaRam.c
@@ -96,10 +96,10 @@ static void destroy(RomMapperOpcodeMegaRam* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0x48);
-    ioPortUnregister(0x49);
-    ioPortUnregister(0x4a);
-    ioPortUnregister(0x4b);
+    ioPortUnregister(0x48, rm);
+    ioPortUnregister(0x49, rm);
+    ioPortUnregister(0x4a, rm);
+    ioPortUnregister(0x4b, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperOpcodeModule.c
+++ b/blueMSX/Src/Memory/romMapperOpcodeModule.c
@@ -139,10 +139,10 @@ static void destroy(RomMapperOpcodeModule* rm)
     debugDeviceUnregister(rm->debugHandle);
     ay8910Destroy(rm->ay8910);
 
-    ioPortUnregister(0x40);
-    ioPortUnregister(0x50);
-    ioPortUnregister(0x51);
-    ioPortUnregister(0x52);
+    ioPortUnregister(0x40, rm);
+    ioPortUnregister(0x50, rm);
+    ioPortUnregister(0x51, rm);
+    ioPortUnregister(0x52, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperOpcodePsg.c
+++ b/blueMSX/Src/Memory/romMapperOpcodePsg.c
@@ -59,9 +59,9 @@ static void destroy(RomMapperOpcodePsg* rm)
     debugDeviceUnregister(rm->debugHandle);
     ay8910Destroy(rm->ay8910);
 
-    ioPortUnregister(0x50);
-    ioPortUnregister(0x51);
-    ioPortUnregister(0x52);
+    ioPortUnregister(0x50, rm);
+    ioPortUnregister(0x51, rm);
+    ioPortUnregister(0x52, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperOpcodeSlotManager.c
+++ b/blueMSX/Src/Memory/romMapperOpcodeSlotManager.c
@@ -74,7 +74,7 @@ static void destroy(RomMapperOpcodeSlotManager* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0x41);
+    ioPortUnregister(0x41, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperS1990.c
+++ b/blueMSX/Src/Memory/romMapperS1990.c
@@ -71,8 +71,8 @@ static void destroy(RomMapperS1990* rm)
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);
 
-    ioPortUnregister(0xe4);
-    ioPortUnregister(0xe5);
+    ioPortUnregister(0xe4, rm);
+    ioPortUnregister(0xe5, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperSonyHBI55.c
+++ b/blueMSX/Src/Memory/romMapperSonyHBI55.c
@@ -58,10 +58,10 @@ typedef struct {
 
 static void destroy(SonyHBI55* rm)
 {
-    ioPortUnregister(0xb0);
-    ioPortUnregister(0xb1);
-    ioPortUnregister(0xb2);
-    ioPortUnregister(0xb3);
+    ioPortUnregister(0xb0, rm->i8255);
+    ioPortUnregister(0xb1, rm->i8255);
+    ioPortUnregister(0xb2, rm->i8255);
+    ioPortUnregister(0xb3, rm->i8255);
     
     sramSave(sramCreateFilename("HBI-55.SRAM"), rm->sram, 0x1000, NULL, 0);
 

--- a/blueMSX/Src/Memory/romMapperSvi328Fdc.c
+++ b/blueMSX/Src/Memory/romMapperSvi328Fdc.c
@@ -68,12 +68,12 @@ static void loadState(Svi328Fdc* rm)
 
 static void destroy(Svi328Fdc* rm)
 {
-    ioPortUnregister(0x30);
-    ioPortUnregister(0x31);
-    ioPortUnregister(0x32);
-    ioPortUnregister(0x33);
-    ioPortUnregister(0x34);
-    ioPortUnregister(0x38);
+    ioPortUnregister(0x30, rm);
+    ioPortUnregister(0x31, rm);
+    ioPortUnregister(0x32, rm);
+    ioPortUnregister(0x33, rm);
+    ioPortUnregister(0x34, rm);
+    ioPortUnregister(0x38, rm);
 
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);

--- a/blueMSX/Src/Memory/romMapperSvi328Prn.c
+++ b/blueMSX/Src/Memory/romMapperSvi328Prn.c
@@ -65,9 +65,9 @@ static void loadState(RomMapperSvi328Prn* prn)
 
 static void destroy(RomMapperSvi328Prn* prn)
 {
-    ioPortUnregister(0x10);
-    ioPortUnregister(0x11);
-    ioPortUnregister(0x12);
+    ioPortUnregister(0x10, prn);
+    ioPortUnregister(0x11, prn);
+    ioPortUnregister(0x12, prn);
 
     deviceManagerUnregister(prn->deviceHandle);
     debugDeviceUnregister(prn->debugHandle);

--- a/blueMSX/Src/Memory/romMapperSvi328Rs232.c
+++ b/blueMSX/Src/Memory/romMapperSvi328Rs232.c
@@ -76,25 +76,25 @@ static void destroy(RomMapperSvi328Rs232* rs232)
 {
     switch (rs232->connector) {
     case SVI328_MODEM:
-        ioPortUnregister(0x20);
-        ioPortUnregister(0x21);
-        ioPortUnregister(0x22);
-        ioPortUnregister(0x23);
-        ioPortUnregister(0x24);
-        ioPortUnregister(0x25);
-        ioPortUnregister(0x26);
-        ioPortUnregister(0x27);
+        ioPortUnregister(0x20, rs232);
+        ioPortUnregister(0x21, rs232);
+        ioPortUnregister(0x22, rs232);
+        ioPortUnregister(0x23, rs232);
+        ioPortUnregister(0x24, rs232);
+        ioPortUnregister(0x25, rs232);
+        ioPortUnregister(0x26, rs232);
+        ioPortUnregister(0x27, rs232);
         break;
 
     case SVI328_RS232:
-        ioPortUnregister(0x28);
-        ioPortUnregister(0x29);
-        ioPortUnregister(0x2A);
-        ioPortUnregister(0x2B);
-        ioPortUnregister(0x2C);
-        ioPortUnregister(0x2D);
-        ioPortUnregister(0x2E);
-        ioPortUnregister(0x2F);
+        ioPortUnregister(0x28, rs232);
+        ioPortUnregister(0x29, rs232);
+        ioPortUnregister(0x2A, rs232);
+        ioPortUnregister(0x2B, rs232);
+        ioPortUnregister(0x2C, rs232);
+        ioPortUnregister(0x2D, rs232);
+        ioPortUnregister(0x2E, rs232);
+        ioPortUnregister(0x2F, rs232);
         break;
     }
     

--- a/blueMSX/Src/Memory/romMapperSvi328RsIDE.c
+++ b/blueMSX/Src/Memory/romMapperSvi328RsIDE.c
@@ -114,10 +114,10 @@ static void loadState(RomMapperRsIde* rm)
 
 static void destroy(RomMapperRsIde* rm)
 {
-    ioPortUnregister(0x14);
-    ioPortUnregister(0x15);
-    ioPortUnregister(0x16);
-    ioPortUnregister(0x17);
+    ioPortUnregister(0x14, rm->i8255);
+    ioPortUnregister(0x15, rm->i8255);
+    ioPortUnregister(0x16, rm->i8255);
+    ioPortUnregister(0x17, rm->i8255);
 
     deviceManagerUnregister(rm->deviceHandle);
     debugDeviceUnregister(rm->debugHandle);

--- a/blueMSX/Src/Memory/romMapperSvi727.c
+++ b/blueMSX/Src/Memory/romMapperSvi727.c
@@ -59,8 +59,8 @@ static void loadState(RomMapperSvi727Col80* rm)
 
 static void destroy(RomMapperSvi727Col80* rm)
 {
-    ioPortUnregister(0x78);
-    ioPortUnregister(0x79);
+    ioPortUnregister(0x78, rm);
+    ioPortUnregister(0x79, rm);
 
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/Memory/romMapperSvi80Col.c
+++ b/blueMSX/Src/Memory/romMapperSvi80Col.c
@@ -65,9 +65,9 @@ static void loadState(RomMapperSvi328Col80* svi328col80)
 static void destroy(RomMapperSvi328Col80* svi328col80)
 {
 
-    ioPortUnregister(0x50);
-    ioPortUnregister(0x51);
-    ioPortUnregister(0x58);
+    ioPortUnregister(0x50, svi328col80);
+    ioPortUnregister(0x51, svi328col80);
+    ioPortUnregister(0x58, svi328col80);
 
     deviceManagerUnregister(svi328col80->deviceHandle);
     debugDeviceUnregister(svi328col80->debugHandle);

--- a/blueMSX/Src/Memory/romMapperTurboRPcm.c
+++ b/blueMSX/Src/Memory/romMapperTurboRPcm.c
@@ -95,8 +95,8 @@ static void destroy(RomMapperTurboRPcm* rm)
     boardTimerDestroy(rm->flushTimer);
     dacDestroy(rm->dac);
 
-    ioPortUnregister(0xa4);
-    ioPortUnregister(0xa5);
+    ioPortUnregister(0xa4, rm);
+    ioPortUnregister(0xa5, rm);
 
     free(rm);
 }

--- a/blueMSX/Src/Memory/romMapperTurboRTimer.c
+++ b/blueMSX/Src/Memory/romMapperTurboRTimer.c
@@ -71,8 +71,8 @@ static void destroy(RomMapperTurboRTimer* rm)
 {
     deviceManagerUnregister(rm->deviceHandle);
 
-    ioPortUnregister(0xe6);
-    ioPortUnregister(0xe7);
+    ioPortUnregister(0xe6, rm);
+    ioPortUnregister(0xe7, rm);
 
     free(rm);
 

--- a/blueMSX/Src/Memory/romMapperYamanooto.c
+++ b/blueMSX/Src/Memory/romMapperYamanooto.c
@@ -155,8 +155,8 @@ static void writeConfigReg(RomMapperYamanooto* rm, UInt8 value)
             ioPortRegister(0xA0, NULL, ioWrite, rm);
             ioPortRegister(0xA1, NULL, ioWrite, rm);
         } else {
-            ioPortUnregister(0xA0);
-            ioPortUnregister(0xA1);
+            ioPortUnregister(0xA0, rm);
+            ioPortUnregister(0xA1, rm);
         }
     }
     if (changed & (MDIS | ROMDIS | K4)) {
@@ -175,12 +175,12 @@ static void destroy(RomMapperYamanooto* rm)
     if (rm->ay8910) {
         ay8910Destroy(rm->ay8910);
     }
-    ioPortUnregister(0x10);
-    ioPortUnregister(0x11);
-    ioPortUnregister(0x12);
+    ioPortUnregister(0x10, rm);
+    ioPortUnregister(0x11, rm);
+    ioPortUnregister(0x12, rm);
     if (rm->configReg & ECHO) {
-        ioPortUnregister(0xA0);
-        ioPortUnregister(0xA1);
+        ioPortUnregister(0xA0, rm);
+        ioPortUnregister(0xA1, rm);
     }
     slotUnregister(rm->slot, rm->sslot, rm->startPage);
     deviceManagerUnregister(rm->deviceHandle);

--- a/blueMSX/Src/SoundChips/AY8910.c
+++ b/blueMSX/Src/SoundChips/AY8910.c
@@ -340,21 +340,21 @@ void ay8910Destroy(AY8910* ay8910)
 
     switch (ay8910->connector) {
     case AY8910_MSX:
-        ioPortUnregister(0xa0);
-        ioPortUnregister(0xa1);
-        ioPortUnregister(0xa2);
+        ioPortUnregister(0xa0, ay8910);
+        ioPortUnregister(0xa1, ay8910);
+        ioPortUnregister(0xa2, ay8910);
         break;
 
     case AY8910_MSX_SCCPLUS:
-        ioPortUnregister(0x10);
-        ioPortUnregister(0x11);
-        ioPortUnregister(0x12);
+        ioPortUnregister(0x10, ay8910);
+        ioPortUnregister(0x11, ay8910);
+        ioPortUnregister(0x12, ay8910);
         break;
 
     case AY8910_SVI:
-        ioPortUnregister(0x88);
-        ioPortUnregister(0x8c);
-        ioPortUnregister(0x90);
+        ioPortUnregister(0x88, ay8910);
+        ioPortUnregister(0x8c, ay8910);
+        ioPortUnregister(0x90, ay8910);
         break;
 
     case AY8910_NONE:

--- a/blueMSX/Src/SoundChips/MsxAudio.cpp
+++ b/blueMSX/Src/SoundChips/MsxAudio.cpp
@@ -139,8 +139,8 @@ extern "C" void msxaudioDestroy(void* rm) {
     MsxAudio* msxaudio = (MsxAudio*)rm;
     deviceManagerUnregister(msxaudio->deviceHandle);
 
-    ioPortUnregister(0xc0);
-    ioPortUnregister(0xc1);
+    ioPortUnregister(0xc0, msxaudio);
+    ioPortUnregister(0xc1, msxaudio);
 
     mixerUnregisterChannel(msxaudio->mixer, msxaudio->handle);
 

--- a/blueMSX/Src/VideoChips/VDP.c
+++ b/blueMSX/Src/VideoChips/VDP.c
@@ -2393,28 +2393,28 @@ static void destroy(VDP* vdp)
 
     switch (vdp->vdpConnector) {
     case VDP_MSX:
-        ioPortUnregister(0x98);
-        ioPortUnregister(0x99);
-        ioPortUnregister(0x9a);
-        ioPortUnregister(0x9b);
+        ioPortUnregister(0x98, vdp);
+        ioPortUnregister(0x99, vdp);
+        ioPortUnregister(0x9a, vdp);
+        ioPortUnregister(0x9b, vdp);
         break;
 
     case VDP_SVI:
-        ioPortUnregister(0x80);
-        ioPortUnregister(0x81);
-        ioPortUnregister(0x84);
-        ioPortUnregister(0x85);
+        ioPortUnregister(0x80, vdp);
+        ioPortUnregister(0x81, vdp);
+        ioPortUnregister(0x84, vdp);
+        ioPortUnregister(0x85, vdp);
         break;
 
     case VDP_COLECO:
         for (i = 0xa0; i < 0xc0; i++) {
-            ioPortUnregister(i);
+            ioPortUnregister(i, vdp);
         }
         break;
 
     case VDP_SG1000:
         for (i = 0x80; i < 0xc0; i++) {
-            ioPortUnregister(i);
+            ioPortUnregister(i, vdp);
         }
         break;
     }


### PR DESCRIPTION
#78 で相談した「1 つの I/O ポートに複数のデバイスを登録できるようにする」変更の実装です。

**提案として出します。** 変更の範囲が広く、`ioPortUnregister` のシグネチャも変わるので、
方針が合わない場合や別の形で直したい場合は、そのまま閉じていただいて構いません。

## 変更内容

`Src/Memory/IoPort.{c,h}`

| | |
|---|---|
| 登録 | 1 ポートあたり 4 件まで持てます。同じ `ref` の再登録は上書きです |
| 書き込み | 登録されたすべてのデバイスに配ります |
| 読み出し | 読み出しを持つデバイスすべての値の AND を返します。実機で複数のカードが同時に応答したときに近いと考えましたが、ここは議論の余地があると思います |
| 解放 | `ioPortUnregister(port, ref)` に `ref` を足しました。自分の登録だけが消えます |

ハンドラの中でポートの登録・解放が起きうる（I/O イネーブラを持つカートリッジがそうします）ので、
配る前に登録の一覧を写してから呼んでいます。

`ioPortUnregister` の呼び出し側は、各ファイルで同じポートを登録している行の `ref` に合わせました。
登録と解放が食い違っていた 3 か所は #77 で直していただいた分です。

`romMapperKorean90.c` と `romMapperMsxAudio.c` は、解放の前に `ioPortGetRef()` で
自分の登録かを確かめていました。`ref` で解放するようになったので不要になり、
残すと 2 番目に登録したデバイスが他人の `ref` を受け取って解放されないまま残るため、外しました。

## 確認したこと

- MSVC 2022 x64 Release でビルドが通ること
- MSX-MUSIC 内蔵の機種に FM-PAC を挿した構成で、BASIC まで起動すること
- C-BIOS の機種でカートリッジが起動すること

この変更を載せたフォークでは、FM-PAC を挿した構成で `7Ch`/`7Dh` への書き込みが
内蔵 MSX-MUSIC と FM-PAC の両方に届くことを、一時的な記録コードで確かめています
（記録コードは含めていません）。

## 確認していないこと

- MSVC 2026 と gcc の Makefile でのビルド
- 読み出しの AND が問題になる組み合わせ（読み出しを持つデバイス同士の重なり）の実機との比較

---

<details>
<summary>English</summary>

This implements what #78 proposed: several devices may register the same I/O port.

**This is a proposal.** It touches many files and changes the signature of
`ioPortUnregister`, so please feel free to close it if the direction does not
fit, or if you would rather solve #78 another way.

## What changes

`Src/Memory/IoPort.{c,h}`

| | |
|---|---|
| Register | Up to 4 claims per port. Registering again with the same `ref` replaces that claim |
| Write | Every claim receives the write |
| Read | The AND of every claim that has a read handler. This is meant to resemble several cards answering on a real bus, but it is open to discussion |
| Release | `ioPortUnregister(port, ref)` takes the `ref`, so only that device's claim goes |

A handler may register or release ports while it runs (cartridges with I/O
enablers do this), so dispatch walks a copy of the claims.

Each `ioPortUnregister` call now passes the `ref` of the matching register
call in the same file. The three release paths that did not match their
register calls were the ones fixed in #77.

`romMapperKorean90.c` and `romMapperMsxAudio.c` asked `ioPortGetRef()` whether
they owned a port before releasing it. With release by `ref` that check is no
longer needed, and keeping it would be wrong: a second claimant would get
someone else's `ref` back and leak its claim. So the check is removed.

## Tested

- Builds with MSVC 2022, x64 Release
- A machine with built-in MSX-MUSIC and an FM-PAC inserted boots to BASIC
- A C-BIOS machine boots a cartridge

On a fork that carries this change, both the built-in MSX-MUSIC and the FM-PAC
received the `7Ch`/`7Dh` writes, checked with temporary logging that is not
part of this change.

## Not tested

- Builds with MSVC 2026 and the gcc Makefile
- How the AND of reads compares with real hardware when two readable devices overlap

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
