### PR TITLE
Add key matrix input over WM_COPYDATA and a /hidden run (proposal)

### DIFF
--- a/blueMSX/Make/gcc/Makefile
+++ b/blueMSX/Make/gcc/Makefile
@@ -349,6 +349,7 @@ SOURCE_FILES += ColecoJoystick.c
 SOURCE_FILES += ColecoSteeringWheel.c
 SOURCE_FILES += ColecoSuperAction.c
 SOURCE_FILES += InputEvent.c
+SOURCE_FILES += KeyMatrixInput.c
 SOURCE_FILES += JoystickPort.c
 SOURCE_FILES += MagicKeyDongle.c
 SOURCE_FILES += MsxArkanoidPad.c

--- a/blueMSX/Make/msvc2022/blueMSX.vcxproj
+++ b/blueMSX/Make/msvc2022/blueMSX.vcxproj
@@ -979,6 +979,7 @@
     <ClCompile Include="..\..\Src\Input\CoinDevice.c" />
     <ClCompile Include="..\..\Src\Input\ColecoJoystick.c" />
     <ClCompile Include="..\..\Src\Input\InputEvent.c" />
+    <ClCompile Include="..\..\Src\Input\KeyMatrixInput.c" />
     <ClCompile Include="..\..\Src\Input\JoystickPort.c" />
     <ClCompile Include="..\..\Src\Input\MagicKeyDongle.c" />
     <ClCompile Include="..\..\Src\Input\MsxArkanoidPad.c" />
@@ -1352,6 +1353,7 @@
     <ClInclude Include="..\..\Src\Input\ColecoJoystick.h" />
     <ClInclude Include="..\..\Src\Input\ColecoJoystickDevice.h" />
     <ClInclude Include="..\..\Src\Input\InputEvent.h" />
+    <ClInclude Include="..\..\Src\Input\KeyMatrixInput.h" />
     <ClInclude Include="..\..\Src\Input\JoystickPort.h" />
     <ClInclude Include="..\..\Src\Input\MagicKeyDongle.h" />
     <ClInclude Include="..\..\Src\Input\MsxArkanoidPad.h" />

--- a/blueMSX/Make/msvc2026/blueMSX.vcxproj
+++ b/blueMSX/Make/msvc2026/blueMSX.vcxproj
@@ -979,6 +979,7 @@
     <ClCompile Include="..\..\Src\Input\CoinDevice.c" />
     <ClCompile Include="..\..\Src\Input\ColecoJoystick.c" />
     <ClCompile Include="..\..\Src\Input\InputEvent.c" />
+    <ClCompile Include="..\..\Src\Input\KeyMatrixInput.c" />
     <ClCompile Include="..\..\Src\Input\JoystickPort.c" />
     <ClCompile Include="..\..\Src\Input\MagicKeyDongle.c" />
     <ClCompile Include="..\..\Src\Input\MsxArkanoidPad.c" />
@@ -1352,6 +1353,7 @@
     <ClInclude Include="..\..\Src\Input\ColecoJoystick.h" />
     <ClInclude Include="..\..\Src\Input\ColecoJoystickDevice.h" />
     <ClInclude Include="..\..\Src\Input\InputEvent.h" />
+    <ClInclude Include="..\..\Src\Input\KeyMatrixInput.h" />
     <ClInclude Include="..\..\Src\Input\JoystickPort.h" />
     <ClInclude Include="..\..\Src\Input\MagicKeyDongle.h" />
     <ClInclude Include="..\..\Src\Input\MsxArkanoidPad.h" />

--- a/blueMSX/Src/Board/Board.c
+++ b/blueMSX/Src/Board/Board.c
@@ -53,6 +53,7 @@
 #include "MediaDb.h"
 #include "RomLoader.h"
 #include "JoystickPort.h"
+#include "KeyMatrixInput.h"
 #include "FileHistory.h"
 #include "Utf8Conv.h"
 
@@ -1453,11 +1454,15 @@ int boardRun(Machine* machine,
             boardTimerAdd(periodicTimer, boardSystemTime() + periodicInterval);
         }
 
+        keyMatrixInputBoardStart();
+
         if (!skipSync) {
             syncToRealClock(0, 0);
         }
 
         boardInfo.run(boardInfo.cpuRef);
+
+        keyMatrixInputBoardStop();
 
         if (periodicTimer != NULL) {
             boardTimerDestroy(periodicTimer);

--- a/blueMSX/Src/Emulator/CommandLine.c
+++ b/blueMSX/Src/Emulator/CommandLine.c
@@ -369,6 +369,7 @@ static const CmdLineOption cmdLineOptions[] = {
     { "speed",         "<pct>",   "Emulation speed, 10 to 1000 percent of normal"    },
     { "vdpspeed",      "<pct>",   "VDP command engine timing, 0 to 100 percent"      },
     { "mute",          NULL,      "Start with the sound muted"                       },
+    { "hidden",        NULL,      "Run without a window, sound or dialogs"           },
     { "msxmusic",      "<on|off>","Enable or disable MSX-Music (YM2413)"             },
     { "msxaudio",      "<on|off>","Enable or disable MSX-Audio (Y8950)"              },
     { "moonsound",     "<on|off>","Enable or disable MoonSound (OPL4)"               },

--- a/blueMSX/Src/Input/InputEvent.c
+++ b/blueMSX/Src/Input/InputEvent.c
@@ -32,6 +32,7 @@
 
 static char* eventNames[256];
 int   eventMap[256];
+int   eventInjected[256];
 
 static void initKeyNameTable()
 {

--- a/blueMSX/Src/Input/InputEvent.h
+++ b/blueMSX/Src/Input/InputEvent.h
@@ -252,6 +252,10 @@ const char* inputEventCodeToString(int eventCode);
 
 // Inlines
 extern int eventMap[256];
+/* Events held from outside the host's input devices (KeyMatrixInput). The
+** keyboard layer clears eventMap whenever the window lacks focus, so these
+** are kept apart and survive that. */
+extern int eventInjected[256];
 
 /* The wheel codes sit outside the contiguous blocks, so they have to be
 ** named here or a port's own events count as MSX keyboard events. */
@@ -270,6 +274,7 @@ extern int eventMap[256];
 
 #define inputEventSet(eventCode) eventMap[eventCode] = 1
 #define inputEventUnset(eventCode) eventMap[eventCode] = 0
-#define inputEventGetState(eventCode) eventMap[eventCode]
+#define inputEventGetState(eventCode) (eventMap[eventCode] | eventInjected[eventCode])
+#define inputEventInject(eventCode, held) eventInjected[eventCode] = (held)
 
 #endif

--- a/blueMSX/Src/Input/KeyMatrixInput.c
+++ b/blueMSX/Src/Input/KeyMatrixInput.c
@@ -39,9 +39,11 @@ typedef struct {
     UInt16 value;       /* the mask, or the wait in milliseconds */
 } Command;
 
-/* The same rows MsxPPI reads, most significant bit first. The events are the
-** ones the host keyboard sets too, so a key pressed here is indistinguishable
-** from one pressed on the keyboard, and key bindings never come into it. */
+/* The same rows MsxPPI reads, most significant bit first. Keys are held in
+** the injected events rather than set like the host keyboard's: the keyboard
+** layer resets its events on every poll while the window has no focus, which
+** would let a held key go within milliseconds. Key bindings never come into
+** it either way. */
 static const int matrix[MATRIX_ROWS][8] = {
     { EC_7,       EC_6,      EC_5,       EC_4,       EC_3,      EC_2,      EC_1,      EC_0      },
     { EC_SEMICOL, EC_LBRACK, EC_AT,      EC_BKSLASH, EC_CIRCFLX,EC_NEG,    EC_9,      EC_8      },
@@ -226,13 +228,7 @@ static void press(int row, int mask, int down)
 
     for (bit = 0; bit < 8; bit++) {
         if (mask & (1 << bit)) {
-            int ec = matrix[row][7 - bit];
-            if (down) {
-                inputEventSet(ec);
-            }
-            else {
-                inputEventUnset(ec);
-            }
+            inputEventInject(matrix[row][7 - bit], down);
         }
     }
     held[row] = (UInt8)(down ? (held[row] | mask) : (held[row] & ~mask));

--- a/blueMSX/Src/Input/KeyMatrixInput.c
+++ b/blueMSX/Src/Input/KeyMatrixInput.c
@@ -1,0 +1,301 @@
+/*****************************************************************************
+**
+** Key presses fed to the MSX keyboard matrix from outside the emulator.
+** Copyright (C) 2026 madscient
+** See https://github.com/Hesoten/blueMSX-plus for change history.
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+******************************************************************************
+*/
+#include "KeyMatrixInput.h"
+#include "InputEvent.h"
+#include "Board.h"
+#include "ArchEvent.h"
+#include <string.h>
+
+#define MATRIX_ROWS     12
+#define QUEUE_SIZE      16384
+#define MAX_WAIT_MS     60000
+#define IDLE_POLL_MS    10
+
+typedef enum { CMD_DOWN, CMD_UP, CMD_WAIT } CommandType;
+
+typedef struct {
+    UInt8  type;
+    UInt8  row;
+    UInt16 value;       /* the mask, or the wait in milliseconds */
+} Command;
+
+/* The same rows MsxPPI reads, most significant bit first. The events are the
+** ones the host keyboard sets too, so a key pressed here is indistinguishable
+** from one pressed on the keyboard, and key bindings never come into it. */
+static const int matrix[MATRIX_ROWS][8] = {
+    { EC_7,       EC_6,      EC_5,       EC_4,       EC_3,      EC_2,      EC_1,      EC_0      },
+    { EC_SEMICOL, EC_LBRACK, EC_AT,      EC_BKSLASH, EC_CIRCFLX,EC_NEG,    EC_9,      EC_8      },
+    { EC_B,       EC_A,      EC_UNDSCRE, EC_DIV,     EC_PERIOD, EC_COMMA,  EC_RBRACK, EC_COLON  },
+    { EC_J,       EC_I,      EC_H,       EC_G,       EC_F,      EC_E,      EC_D,      EC_C      },
+    { EC_R,       EC_Q,      EC_P,       EC_O,       EC_N,      EC_M,      EC_L,      EC_K      },
+    { EC_Z,       EC_Y,      EC_X,       EC_W,       EC_V,      EC_U,      EC_T,      EC_S      },
+    { EC_F3,      EC_F2,     EC_F1,      EC_CODE,    EC_CAPS,   EC_GRAPH,  EC_CTRL,   EC_LSHIFT },
+    { EC_RETURN,  EC_SELECT, EC_BKSPACE, EC_STOP,    EC_TAB,    EC_ESC,    EC_F5,     EC_F4     },
+    { EC_RIGHT,   EC_DOWN,   EC_UP,      EC_LEFT,    EC_DEL,    EC_INS,    EC_CLS,    EC_SPACE  },
+    { EC_NUM4,    EC_NUM3,   EC_NUM2,    EC_NUM1,    EC_NUM0,   EC_NUMDIV, EC_NUMADD, EC_NUMMUL },
+    { EC_NUMPER,  EC_NUMCOM, EC_NUMSUB,  EC_NUM9,    EC_NUM8,   EC_NUM7,   EC_NUM6,   EC_NUM5   },
+    { EC_NONE,    EC_NONE,   EC_NONE,    EC_NONE,    EC_TORIKE, EC_NONE,   EC_JIKKOU, EC_NONE   },
+};
+
+/* The queue is filled by whoever receives a request and emptied on the
+** emulation thread, so both sides take the lock. */
+static void*       lock;
+static Command     queue[QUEUE_SIZE];
+static int         head;
+static int         count;
+static int         waiting;
+static UInt8       held[MATRIX_ROWS];
+static BoardTimer* timer;
+
+static void takeLock(void)
+{
+    if (lock != NULL) {
+        archSemaphoreWait(lock, -1);
+    }
+}
+
+static void dropLock(void)
+{
+    if (lock != NULL) {
+        archSemaphoreSignal(lock);
+    }
+}
+
+void keyMatrixInputInit(void)
+{
+    if (lock == NULL) {
+        lock = archSemaphoreCreate(1);
+    }
+}
+
+static int isSpace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+/* Decimal, or hexadecimal after 0x. Anything else, a sign included, fails. */
+static const char* parseNumber(const char* p, UInt32* value)
+{
+    UInt32 v = 0;
+    int digits = 0;
+
+    if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        for (p += 2; ; p++, digits++) {
+            int d;
+            if      (*p >= '0' && *p <= '9') d = *p - '0';
+            else if (*p >= 'a' && *p <= 'f') d = *p - 'a' + 10;
+            else if (*p >= 'A' && *p <= 'F') d = *p - 'A' + 10;
+            else break;
+            if (v > 0x0fffffff) return NULL;
+            v = v * 16 + d;
+        }
+    }
+    else {
+        for (; *p >= '0' && *p <= '9'; p++, digits++) {
+            if (v > 429496728) return NULL;
+            v = v * 10 + (*p - '0');
+        }
+    }
+    if (digits == 0 || !(*p == 0 || isSpace(*p))) {
+        return NULL;
+    }
+    *value = v;
+    return p;
+}
+
+static const char* skipSpace(const char* p)
+{
+    while (isSpace(*p)) p++;
+    return p;
+}
+
+static int maskHasOnlyKeys(int row, UInt32 mask)
+{
+    int bit;
+
+    if (mask == 0 || mask > 0xff) {
+        return 0;
+    }
+    for (bit = 0; bit < 8; bit++) {
+        if ((mask & (1 << bit)) && matrix[row][7 - bit] == EC_NONE) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Fills out[] from text; returns the number of commands, or -1. */
+static int parse(const char* text, Command* out, int room)
+{
+    const char* p = skipSpace(text);
+    int n = 0;
+
+    while (*p) {
+        char op = *p++;
+        UInt32 a, b;
+
+        if (!isSpace(*p) || n == room) {
+            return -1;
+        }
+        p = skipSpace(p);
+
+        switch (op) {
+        case 'd':
+        case 'u':
+            if ((p = parseNumber(p, &a)) == NULL) return -1;
+            p = skipSpace(p);
+            if ((p = parseNumber(p, &b)) == NULL) return -1;
+            if (a >= MATRIX_ROWS || !maskHasOnlyKeys((int)a, b)) return -1;
+            out[n].type  = op == 'd' ? CMD_DOWN : CMD_UP;
+            out[n].row   = (UInt8)a;
+            out[n].value = (UInt16)b;
+            break;
+        case 'w':
+            if ((p = parseNumber(p, &a)) == NULL) return -1;
+            if (a > MAX_WAIT_MS) return -1;
+            out[n].type  = CMD_WAIT;
+            out[n].row   = 0;
+            out[n].value = (UInt16)a;
+            break;
+        default:
+            return -1;
+        }
+        n++;
+        p = skipSpace(p);
+    }
+    return n;
+}
+
+int keyMatrixInputSubmit(const char* text)
+{
+    static Command parsed[QUEUE_SIZE];
+    int n;
+    int i;
+    int ok;
+
+    if (text == NULL || boardGetType() != BOARD_MSX) {
+        return 0;
+    }
+
+    takeLock();
+    n = parse(text, parsed, QUEUE_SIZE - count);
+    ok = n > 0;
+    for (i = 0; ok && i < n; i++) {
+        queue[(head + count) % QUEUE_SIZE] = parsed[i];
+        count++;
+    }
+    dropLock();
+
+    return ok;
+}
+
+int keyMatrixInputRemaining(void)
+{
+    int n;
+
+    takeLock();
+    n = count;
+    dropLock();
+
+    return n;
+}
+
+static void press(int row, int mask, int down)
+{
+    int bit;
+
+    for (bit = 0; bit < 8; bit++) {
+        if (mask & (1 << bit)) {
+            int ec = matrix[row][7 - bit];
+            if (down) {
+                inputEventSet(ec);
+            }
+            else {
+                inputEventUnset(ec);
+            }
+        }
+    }
+    held[row] = (UInt8)(down ? (held[row] | mask) : (held[row] & ~mask));
+}
+
+/* Carries out commands until a wait or the end of the queue, and sleeps until
+** the wait is over; with nothing queued it looks again every few
+** milliseconds. */
+static void onTimer(void* ref, UInt32 time)
+{
+    UInt32 next = time + boardFrequency() / 1000 * IDLE_POLL_MS;
+
+    takeLock();
+
+    if (waiting) {
+        head = (head + 1) % QUEUE_SIZE;
+        count--;
+        waiting = 0;
+    }
+
+    while (count > 0) {
+        Command* c = &queue[head];
+
+        if (c->type == CMD_WAIT) {
+            waiting = 1;
+            next = time + boardFrequency() / 1000 * c->value;
+            break;
+        }
+        press(c->row, c->value, c->type == CMD_DOWN);
+        head = (head + 1) % QUEUE_SIZE;
+        count--;
+    }
+
+    dropLock();
+
+    boardTimerAdd(timer, next);
+}
+
+void keyMatrixInputBoardStart(void)
+{
+    timer = boardTimerCreate(onTimer, NULL);
+    boardTimerAdd(timer, boardSystemTime() + 1);
+}
+
+/* Whatever was still queued belonged to the run that ended. Keys pressed here
+** are let go, so none stays down into the next run. */
+void keyMatrixInputBoardStop(void)
+{
+    int row;
+
+    if (timer != NULL) {
+        boardTimerDestroy(timer);
+        timer = NULL;
+    }
+
+    takeLock();
+    for (row = 0; row < MATRIX_ROWS; row++) {
+        if (held[row]) {
+            press(row, held[row], 0);
+        }
+    }
+    head = 0;
+    count = 0;
+    waiting = 0;
+    dropLock();
+}

--- a/blueMSX/Src/Input/KeyMatrixInput.h
+++ b/blueMSX/Src/Input/KeyMatrixInput.h
@@ -1,0 +1,50 @@
+/*****************************************************************************
+**
+** Key presses fed to the MSX keyboard matrix from outside the emulator.
+** Copyright (C) 2026 madscient
+** See https://github.com/Hesoten/blueMSX-plus for change history.
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+******************************************************************************
+*/
+#ifndef KEY_MATRIX_INPUT_H
+#define KEY_MATRIX_INPUT_H
+
+/* A request is ASCII text of commands separated by white space:
+**
+**   d <row> <mask>   press the keys of <mask> in matrix row <row>
+**   u <row> <mask>   release them
+**   w <ms>           wait <ms> milliseconds of emulated time
+**
+** Numbers are decimal, or hexadecimal with a 0x prefix. Rows are 0-11 and a
+** mask may only name bits that have a key. Which character a key gives is up
+** to the MSX, so nothing here knows about keyboard layouts.
+*/
+
+void keyMatrixInputInit(void);
+
+/* Queues a whole request, or nothing: returns 0 when any part is malformed,
+** out of range, or the running board has no MSX keyboard matrix. */
+int keyMatrixInputSubmit(const char* text);
+
+/* Commands queued and not yet carried out; a wait counts until it ends. */
+int keyMatrixInputRemaining(void);
+
+/* Called by the board around a run, from the emulation thread. */
+void keyMatrixInputBoardStart(void);
+void keyMatrixInputBoardStop(void);
+
+#endif

--- a/blueMSX/Src/Win32/Win32.c
+++ b/blueMSX/Src/Win32/Win32.c
@@ -3715,7 +3715,10 @@ static LRESULT CALLBACK wndProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lPar
                 int i;
                 HWND hwndFocus = GetFocus();
 
-                keyboardSetFocus(1, hwndFocus == st.hwnd || hwndFocus == st.emuHwnd);
+                /* GetFocus answers for this thread even while another program
+                ** is in front, and the keyboard device reads in the background,
+                ** so a hidden instance would take the keys typed elsewhere. */
+                keyboardSetFocus(1, !st.hidden && (hwndFocus == st.hwnd || hwndFocus == st.emuHwnd));
                 
                 if (emulatorGetState() != EMU_RUNNING) {
                     archPollInput();

--- a/blueMSX/Src/Win32/Win32.c
+++ b/blueMSX/Src/Win32/Win32.c
@@ -64,6 +64,7 @@
 #include "FrameBuffer.h"
 #include "Win32Midi.h"
 #include "Win32Sound.h"
+#include "KeyMatrixInput.h"
 #include "Win32Properties.h"
 #include "Win32ToolLoader.h"
 #include "Win32joystick.h"
@@ -1981,6 +1982,8 @@ typedef struct {
     char pCurDir[MAX_PATH];
     Video* pVideo;
     int minimized;
+    /* Started with /hidden: never shown, silent, and no dialogs. */
+    int hidden;
     Mixer* mixer;
     int enteringFullscreen;
     Shortcuts* shortcuts;
@@ -2030,6 +2033,8 @@ typedef struct {
 
 /* Marks a WM_COPYDATA as ours, so another build of the same class ignores it. */
 #define LAUNCH_COPYDATA_ID   0x424D5846
+/* Key matrix commands (KeyMatrixInput.h); an empty one asks how many are left. */
+#define KEYMATRIX_COPYDATA_ID 0x424D5854
 
 /* Fills path with the exe of processId. QueryFullProcessImageNameW is used for
 ** this process too, so the two paths compare equal. */
@@ -2075,6 +2080,12 @@ static HWND findRunningInstance(void)
     while ((hwnd = FindWindowEx(NULL, hwnd, "blueMSX", NULL)) != NULL) {
         wchar_t other[1024];
         DWORD processId = 0;
+
+        /* A hidden instance belongs to a script; a double clicked file has to
+        ** open where the user can see it. */
+        if (!IsWindowVisible(hwnd)) {
+            continue;
+        }
 
         GetWindowThreadProcessId(hwnd, &processId);
         if (imagePathOf(processId, other, _countof(other)) &&
@@ -2655,7 +2666,7 @@ void themeSet(char* themeName, int forceMatch) {
             eh = appConfigGetInt("screen.normal.height", 480);
         }
 
-        SetWindowPos(st.hwnd, z, x, y, w, h, SWP_SHOWWINDOW);
+        SetWindowPos(st.hwnd, z, x, y, w, h, st.hidden ? SWP_NOACTIVATE : SWP_SHOWWINDOW);
         SetWindowPos(st.emuHwnd, NULL, ex, ey, ew, eh, SWP_NOZORDER);
     }
 
@@ -3235,6 +3246,22 @@ static LRESULT CALLBACK wndProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lPar
             COPYDATASTRUCT* cds = (COPYDATASTRUCT*)lParam;
             char candidate[PROP_MAXPATH];
             char* pending;
+
+            if (cds != NULL && cds->dwData == KEYMATRIX_COPYDATA_ID) {
+                const char* text = (const char*)cds->lpData;
+
+                if (text == NULL || cds->cbData == 0 || text[0] == 0) {
+                    return keyMatrixInputRemaining();
+                }
+                if (text[cds->cbData - 1] != 0) {
+                    return FALSE;
+                }
+                return keyMatrixInputSubmit(text) ? TRUE : FALSE;
+            }
+
+            if (st.hidden) {
+                return FALSE;
+            }
 
             if (cds == NULL || cds->dwData != LAUNCH_COPYDATA_ID ||
                 cds->lpData == NULL || cds->cbData == 0 ||
@@ -4459,10 +4486,18 @@ static void commandLineReport(const char* message)
     sprintf(text, "blueMSX+: %s\r\n", message);
     /* This goes to the error stream, or a redirected listing would collect the
     ** complaint too. */
-    if (!consoleWriteTo(STD_ERROR_HANDLE, text)) {
+    if (!consoleWriteTo(STD_ERROR_HANDLE, text) && !st.hidden) {
         /* Not langErrorTitle(): the language table is not built this early. */
         MessageBoxU(NULL, message, "blueMSX+", MB_OK | MB_ICONERROR);
     }
+}
+
+/* A hidden run has no one to click a dialog away, so a failure to start ends
+** the process with its own exit code instead. */
+static void hiddenStartFail(const char* message)
+{
+    commandLineReport(message);
+    exit(2);
 }
 
 static void commandLineFail(const char* message)
@@ -4651,6 +4686,8 @@ WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, PSTR szLine, int iShow)
 #else
     szLine = commandLineUtf8();
 #endif
+
+    st.hidden = emuCheckFlagArgument(szLine, "hidden");
 
     /* This is done first, because everything below moves to the exe directory. */
     if (GetCurrentDirectoryU(sizeof(launchDir) - 1, launchDir) == 0 || launchDir[0] == 0) {
@@ -4849,6 +4886,20 @@ WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, PSTR szLine, int iShow)
             ** part it had applied. */
             commandLineFail(emuCommandLineGetError());
         }
+    }
+
+    /* Nothing a hidden run does may wait on a person: files get their
+    ** automatic names, no toast pops up, and full screen would show. */
+    if (st.hidden) {
+        emuCommandLineOverrideInt(&pProperties->capture.audioPromptFilename, 0);
+        emuCommandLineOverrideInt(&pProperties->capture.videoPromptFilename, 0);
+        emuCommandLineOverrideInt(&pProperties->capture.screenshotPromptFilename, 0);
+        emuCommandLineOverrideInt(&pProperties->capture.replayPromptFilename, 0);
+        emuCommandLineOverrideInt(&pProperties->capture.showCompletionToast, 0);
+        if (pProperties->video.windowSize == P_VIDEO_SIZEFULLSCREEN) {
+            emuCommandLineOverrideInt(&pProperties->video.windowSize, P_VIDEO_SIZEX2);
+        }
+        joystickSetPolling(0);
     }
 
     /* An INI capture.* path wins; otherwise the rootDir default goes back for
@@ -5111,8 +5162,11 @@ WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, PSTR szLine, int iShow)
 
     st.enteringFullscreen = 0;
 
-    soundDriverConfig(st.hwnd, pProperties->sound.driver);
+    /* With no driver the mixer still runs, so a WAV capture keeps recording. */
+    soundDriverConfig(st.hwnd, st.hidden ? SOUND_DRV_NONE : pProperties->sound.driver);
     emulatorRestartSound();
+
+    keyMatrixInputInit();
 
     /* Driver runs 2ch unconditionally; bring mixer's stereo flag in line
     ** with the user's saved preference now that the driver no longer
@@ -5197,8 +5251,10 @@ WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, PSTR szLine, int iShow)
     }
 
     archUpdateWindow();
-    ShowWindow(st.hwnd, SW_NORMAL);
-    UpdateWindow(st.hwnd);
+    if (!st.hidden) {
+        ShowWindow(st.hwnd, SW_NORMAL);
+        UpdateWindow(st.hwnd);
+    }
 
     /* The debugger attaches to the main window, so this runs after it exists. */
     if (emuCheckFlagArgument(szLine, "debugger")) {
@@ -5222,7 +5278,12 @@ WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, PSTR szLine, int iShow)
             DispatchMessage(&msg);
         }
         if (rv == WAIT_OBJECT_0) {
-            if (!st.minimized) {
+            /* The drivers flip the view frame as they draw. A hidden run draws
+            ** nothing, so it flips here, which is what a screenshot reads. */
+            if (st.hidden) {
+                frameBufferFlipViewFrame(0);
+            }
+            else if (!st.minimized) {
                 emuWindowDraw(st.diplayUpdateOnVblank);
             }
             SetEvent(st.ddrawAckEvent);
@@ -5564,6 +5625,18 @@ int MessageBoxLargeU(HWND hwnd, const char* mainInstr, const char* content,
 static void showStartEmuFailDialogShared(void)
 {
     int n = boardGetMissingFileCount();
+
+    if (st.hidden) {
+        char text[4096];
+        int  off = _snprintf(text, sizeof(text) - 1, "%s", langErrorStartEmu());
+        int  i;
+        for (i = 0; i < n && off >= 0 && off < (int)sizeof(text) - 256; i++) {
+            off += _snprintf(text + off, sizeof(text) - off - 1, " %s", boardGetMissingFile(i));
+        }
+        text[sizeof(text) - 1] = 0;
+        hiddenStartFail(text);
+    }
+
     if (n > 0) {
         /* Use the TaskDialog "main instruction" line for the headline so the
         ** missing-files list (small body text) is visually distinct from the
@@ -5617,6 +5690,10 @@ void archShowStartEmuFailDialog(const char* machineName)
         break;
     }
     body[sizeof(body) - 1] = 0;
+
+    if (st.hidden) {
+        hiddenStartFail(body);
+    }
 
     MessageBoxLargeU(NULL, langErrorStartEmu(), body, langErrorTitle(),
                      MB_ICONHAND | MB_OK);

--- a/blueMSX/Src/Win32/Win32keyboard.c
+++ b/blueMSX/Src/Win32/Win32keyboard.c
@@ -2491,9 +2491,20 @@ void archKeyboardSetSelectedKey(int msxKeyCode) {
     }
 }
 
+/* Pads are read without focus, which a hidden instance must not do: it would
+** take the input of whoever is using the pad elsewhere. */
+static int joystickPolling = 1;
+
+void joystickSetPolling(int enable)
+{
+    joystickPolling = enable;
+}
+
 void archPollInput() {
     keyboardUpdate();
-    joystickUpdate();
+    if (joystickPolling) {
+        joystickUpdate();
+    }
 }
 
 int archKeyboardIsKeySelected(int msxKeyCode)

--- a/blueMSX/Src/Win32/Win32keyboard.h
+++ b/blueMSX/Src/Win32/Win32keyboard.h
@@ -112,6 +112,7 @@ int keyboardIsImeLatchKey(int scan, int vk);
 int keyboardGetModifiers();
 
 void joystickUpdate();
+void joystickSetPolling(int enable);
 DWORD joystickGetButtonState();
 /* Zero for a slot with no device; joystickGetButtonState merges all
 ** slots. */


### PR DESCRIPTION
エミュレータを外部のスクリプトから試験に使うための機能を 2 つ足しました。

**提案として出します。** 外から見える値（`WM_COPYDATA` の識別子、要求の書式、`/hidden` の名前と振る舞い）を
含むので、形が合わない場合はそのまま閉じていただくか、ご指摘ください。
#78 の変更（別のプルリクエスト）とは独立しています。

## 1. `WM_COPYDATA` でキーマトリクスを押す

`dwData` = `0x424D5854` の `WM_COPYDATA` で、ASCII のコマンド列を送ります（NUL 終端、空白区切り）。

| コマンド | 意味 |
|---|---|
| `d <row> <mask>` | 行 `row` の `mask` のキーを押す |
| `u <row> <mask>` | 離す |
| `w <ms>` | エミュレーション時間で `ms` ミリ秒待つ（60000 まで） |

- 数値は 10 進か `0x` 付きの 16 進です。行は 0-11 で、キーの無いビットは指定できません
- 応答は、要求全体をキューに積めたら `1`、どこか一つでも不正なら `0`（何も積みません）。MSX 系以外の基盤でも `0` です
- 空の要求には、まだ実行していないコマンドの数を返します（`w` は待ち終わるまで 1 件）。打ち終わりの確認に使えます

キーは `MsxPPI` が読む入力イベントに直接入れるので、**キーバインドの設定やウィンドウの
フォーカスの影響を受けません。** どの文字になるかは MSX 側の配列が決めるので、
エミュレータは配列を知りません（openMSX の `keymatrixdown` / `keymatrixup` と同じ粒度です）。
コマンドはボードタイマで実行するので、待ち時間はホストの速さに左右されません。

## 2. `/hidden`

- ウィンドウを表示せず、ビデオドライバに描かせません。ビューフレームの切り替えは行うので、スクリーンショットは撮れます
- 音のドライバを開きません。ミキサーは動くので、WAV の書き出しは録れます
- 保存先を尋ねるダイアログと完了のトーストを出しません。フルスクリーン指定は x2 にします
- 起動の失敗はダイアログを出さず、stderr に書いて終了コード 2 で終わります（コマンドラインの誤りは従来どおり 1 で、ダイアログは出しません）
- 別の起動から渡されるファイル（ダブルクリック）を受け付けず、渡す側も表示中のインスタンスだけを探します
- ゲームパッドを読みません（フォーカスが無くても読まれるため、他のアプリで使っているパッドの入力を取ってしまいます）

終了はスクリプト側から `WM_CLOSE` を送ります。

## 確認したこと

`CHGET` で受け取った文字を表示して期待する行と比べる、C-BIOS 用の小さなカートリッジで試しました。

- `/hidden` で `HELLO, MSX 123!` と RETURN を押して、期待どおりの行が届くこと（スクリーンショットで確認）
- 不正な要求（行 12、キーの無いビット、未知のコマンド、数値の欠落、符号付き）を `0` で拒否すること
- 残りの件数が打ち終わりで 0 になること
- `/hidden` で、プロセスのウィンドウが一つも表示されないこと、渡されたファイルを受け付けないこと
- `/hidden` で WAV の書き出しが録れること
- 行列のビット順を逆にしたビルドでは文字が化けること（試験が壊れた実装を見分けること）

押す長さは 80 ms にしました。40 ms では文字を取りこぼしました。

## 確認していないこと

- 起動失敗で終了コード 2 になる経路（コマンドラインの検査が先に捕まえるため、届きませんでした）
- ゲームパッドを読まないこと（パッドが手元にありません）
- MSVC 2026 と gcc の Makefile でのビルド

---

<details>
<summary>English</summary>

Two additions that let external scripts use the emulator for testing.

**This is a proposal.** It adds externally visible values (a `WM_COPYDATA` id,
a request format, and the name and behaviour of `/hidden`), so please close it
or point out what should change if the shape does not fit. It is independent of
the #78 change, which is a separate pull request.

## 1. Pressing keys in the key matrix through `WM_COPYDATA`

A `WM_COPYDATA` with `dwData` = `0x424D5854` carries ASCII commands,
NUL-terminated and separated by white space.

| Command | Meaning |
|---|---|
| `d <row> <mask>` | Press the keys of `mask` in matrix row `row` |
| `u <row> <mask>` | Release them |
| `w <ms>` | Wait `ms` milliseconds of emulated time (up to 60000) |

- Numbers are decimal, or hexadecimal with `0x`. Rows are 0-11, and a mask may only name bits that have a key
- The answer is `1` when the whole request is queued, and `0` when any part is malformed (nothing is queued). It is also `0` on a board that is not an MSX
- An empty request answers with the number of commands not yet carried out (a `w` counts until it ends), which tells a script when typing is done

The keys go straight into the input events `MsxPPI` reads, so **key bindings
and window focus do not affect them**. Which character a key gives is left to
the MSX's own layout, so the emulator knows nothing about layouts (the same
granularity as openMSX's `keymatrixdown` / `keymatrixup`). Commands run on a
board timer, so waits do not depend on host speed.

## 2. `/hidden`

- The window is never shown and the video driver does not draw. The view frame is still flipped, so screenshots work
- No sound driver is opened. The mixer runs, so WAV capture still records
- Capture prompts and completion toasts are off, and full screen becomes x2
- A start failure writes to stderr and exits with code 2 instead of showing a dialog (command-line errors keep exit code 1, without a dialog)
- A file handed over by another launch (a double click) is refused, and a launch only looks for visible instances
- Game pads are not polled, since they are read without focus and would take input from a pad in use elsewhere

Scripts end the run by sending `WM_CLOSE`.

## Tested

With a small C-BIOS cartridge that shows what `CHGET` returns and compares it with the expected line:

- In a `/hidden` run, typing `HELLO, MSX 123!` and RETURN delivers the expected line (checked in a screenshot)
- Malformed requests (row 12, a bit with no key, an unknown command, a missing number, a sign) answer `0`
- The remaining count reaches 0 when typing ends
- With `/hidden`, no window of the process becomes visible, and a handed-over file is refused
- With `/hidden`, WAV capture records
- A build with the matrix bit order reversed types garbage, so the test tells a broken implementation apart

Keys are held for 80 ms. At 40 ms some characters were lost.

## Not tested

- The start failure path with exit code 2 (the command-line checks caught every case first)
- That game pads are not read (no pad at hand)
- Builds with MSVC 2026 and the gcc Makefile

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
